### PR TITLE
Rename to Cluesive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# 🎯 Clue
+# 🎯 Cluesive
 
-A **lightweight**, **type-safe**, **fault-tolerant** event tracking library for modern web applications. Clue Core delivers essential tracking functionality with a modular, plugin-based architecture, making it ideal for high-performance applications while minimizing bundle size.
+A **lightweight**, **type-safe**, **fault-tolerant** event tracking library for modern web applications. Cluesive Core delivers essential tracking functionality with a modular, plugin-based architecture, making it ideal for high-performance applications while minimizing bundle size.
 
-[![npm version](https://img.shields.io/npm/v/@clue/core.svg)](https://www.npmjs.com/package/@clue/core)
-[![bundle size](https://img.shields.io/bundlephobia/minzip/@clue/core)](https://bundlephobia.com/package/@clue/core)
+[![npm version](https://img.shields.io/npm/v/@cluesive/core.svg)](https://www.npmjs.com/package/@cluesive/core)
+[![bundle size](https://img.shields.io/bundlephobia/minzip/@cluesive/core)](https://bundlephobia.com/package/@cluesive/core)
 [![TypeScript](https://img.shields.io/badge/TypeScript-Ready-blue.svg)](https://www.typescriptlang.org)
 
 ---
@@ -26,7 +26,7 @@ A **lightweight**, **type-safe**, **fault-tolerant** event tracking library for 
 
 ### 🔄 Automatic Context Inheritance
 
-Clue Core’s **Automatic Context Inheritance** feature simplifies event tracking by automatically gathering contextual data from parent elements up the DOM hierarchy. This provides fully contextualized events without redundant declarations and is ideal for applications with complex or deeply nested components.
+Cluesive Core’s **Automatic Context Inheritance** feature simplifies event tracking by automatically gathering contextual data from parent elements up the DOM hierarchy. This provides fully contextualized events without redundant declarations and is ideal for applications with complex or deeply nested components.
 
 **Benefits**:
 
@@ -36,7 +36,7 @@ Clue Core’s **Automatic Context Inheritance** feature simplifies event trackin
 
 ### 🔄 Smart Retry Logic
 
-To ensure fault tolerance, Clue Core automatically retries failed event transmissions using exponential backoff. This feature ensures data reliability even under network instability.
+To ensure fault tolerance, Cluesive Core automatically retries failed event transmissions using exponential backoff. This feature ensures data reliability even under network instability.
 
 **Retry Logic**:
 
@@ -52,15 +52,15 @@ To ensure fault tolerance, Clue Core automatically retries failed event transmis
 
 ### 🌐 Offline Support
 
-Clue Core includes built-in offline support, queuing events when users are offline and automatically syncing them upon reconnection. This feature is essential for applications with users on unstable networks, ensuring no data loss during offline periods.
+Cluesive Core includes built-in offline support, queuing events when users are offline and automatically syncing them upon reconnection. This feature is essential for applications with users on unstable networks, ensuring no data loss during offline periods.
 
 ### 📦 Smart Batching
 
-With smart batching, Clue Core efficiently groups events to reduce the number of network requests, minimizing the impact on bandwidth and enhancing performance. Batching parameters like `syncingInterval` and `maxBatchSizeInKB` can be configured to adjust the frequency and size of batches, striking a balance between real-time data and network load.
+With smart batching, Cluesive Core efficiently groups events to reduce the number of network requests, minimizing the impact on bandwidth and enhancing performance. Batching parameters like `syncingInterval` and `maxBatchSizeInKB` can be configured to adjust the frequency and size of batches, striking a balance between real-time data and network load.
 
 ### 🔧 Middleware Support
 
-Clue Core enables you to add custom middleware functions that can transform, enrich, or validate events before they are sent. Middleware functions can be used to:
+Cluesive Core enables you to add custom middleware functions that can transform, enrich, or validate events before they are sent. Middleware functions can be used to:
 
 - Append additional context (e.g., environment, viewport size)
 - Filter out sensitive data
@@ -68,27 +68,27 @@ Clue Core enables you to add custom middleware functions that can transform, enr
 
 ### 🚀 Lightweight
 
-Clue Core is optimized for performance with the minimal dependencies, making it highly suitable for resource-conscious applications. Its modular design means you can include only the plugins you need, further keeping your bundle size minimal.
+Cluesive Core is optimized for performance with the minimal dependencies, making it highly suitable for resource-conscious applications. Its modular design means you can include only the plugins you need, further keeping your bundle size minimal.
 
 ---
 
 ## 📦 Installation
 
-To install Clue Core, use the following command:
+To install Cluesive Core, use the following command:
 
 ```bash
-npm install @clue/core
+npm install @cluesive/core
 ```
 
 ---
 
 ## 🚀 Quick Start
 
-Here’s a quick guide to setting up Clue Core and starting event tracking with context inheritance:
+Here’s a quick guide to setting up Cluesive Core and starting event tracking with context inheritance:
 
 ```typescript
-import { CoreTracker } from "@clue/core";
-import { ClickTracker } from "@clue/click-tracker";
+import { CoreTracker } from "@cluesive/core";
+import { ClickTracker } from "@cluesive/click-tracker";
 
 // Initialize the tracker
 const tracker = CoreTracker.getInstance({
@@ -124,33 +124,33 @@ tracker.start();
 
 ### Example 1: Click Tracking with Context Inheritance
 
-In this example, context attributes are defined at various levels, such as app-level, section-level, and action-specific contexts. Clue Core automatically collects and combines these attributes so that each event has full context.
+In this example, context attributes are defined at various levels, such as app-level, section-level, and action-specific contexts. Cluesive Core automatically collects and combines these attributes so that each event has full context.
 
 ```html
 <!-- App Shell: Global context for all events -->
-<div data-clue-context='{"app":"myapp","version":"1.0.0"}'>
+<div data-cv-context='{"app":"myapp","version":"1.0.0"}'>
   <!-- Navigation Section -->
-  <nav data-clue-context='{"section":"navigation"}'>
+  <nav data-cv-context='{"section":"navigation"}'>
     <button
-      data-clue-click="true"
-      data-clue-id="menu-toggle"
-      data-clue-context='{"action":"toggle-menu"}'
+      data-cv-click="true"
+      data-cv-id="menu-toggle"
+      data-cv-context='{"action":"toggle-menu"}'
     >
       Menu
     </button>
   </nav>
 
   <!-- Main Content with Nested Contexts -->
-  <main data-clue-context='{"section":"content"}'>
+  <main data-cv-context='{"section":"content"}'>
     <!-- Product Section -->
     <section
-      data-clue-context='{"subsection":"products","category":"electronics"}'
+      data-cv-context='{"subsection":"products","category":"electronics"}'
     >
-      <div data-clue-context='{"product":"laptop","price":999}'>
+      <div data-cv-context='{"product":"laptop","price":999}'>
         <button
-          data-clue-click="true"
-          data-clue-id="add-to-cart"
-          data-clue-context='{"action":"add-to-cart"}'
+          data-cv-click="true"
+          data-cv-id="add-to-cart"
+          data-cv-context='{"action":"add-to-cart"}'
         >
           Add to Cart
         </button>
@@ -252,11 +252,11 @@ CoreTracker.getInstance({
 
 ## 🔌 Available Plugins
 
-- [@clue/click-tracker](https://www.npmjs.com/package/@clue/click-tracker): Easily track click events.
+- [@cluesive/click-tracker](https://www.npmjs.com/package/@cluesive/click-tracker): Easily track click events.
 - More plugins are on the way!
 
 ---
 
 ## 📝 License
 
-MIT © Clue
+MIT © Cluesive

--- a/examples/react/package-lock.json
+++ b/examples/react/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "clue-example-react",
+  "name": "cluesive-example-react",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "clue-example-react",
+      "name": "cluesive-example-react",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "clue-example-react",
+  "name": "cluesive-example-react",
   "version": "1.0.0",
   "type": "module",
   "scripts": {

--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from "react";
-import { Clue } from "@clue/core";
-import { ClickTracker } from "@clue/click-tracker";
+import { Cluesive } from "@cluesive/core";
+import { ClickTracker } from "@cluesive/click-tracker";
 
 export function App() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   useEffect(() => {
-    const tracker = Clue.init({
+    const tracker = Cluesive.init({
       debug: true,
       endpoint: "https://api.example.com/events",
       maxBatchSizeInKB: 100,
@@ -43,7 +43,7 @@ export function App() {
   return (
     <div
       className="min-h-screen bg-gradient-to-br from-gray-900 to-gray-800 text-white p-8"
-      data-clue-context={JSON.stringify({
+      data-cv-context={JSON.stringify({
         pageName: "Home",
       })}
     >
@@ -53,13 +53,13 @@ export function App() {
             <button
               onClick={() => setIsMenuOpen(!isMenuOpen)}
               className="p-2 hover:bg-gray-700 rounded-lg transition-colors"
-              data-clue-id="menu-toggle"
-              data-clue-click
-              data-clue-context='{"location":"header"}'
+              data-cv-id="menu-toggle"
+              data-cv-click
+              data-cv-context='{"location":"header"}'
             >
               Hamburger Menu
             </button>
-            <h1 className="text-2xl font-bold">clue Demo</h1>
+            <h1 className="text-2xl font-bold">cluesive Demo</h1>
           </div>
         </nav>
       </header>
@@ -70,13 +70,13 @@ export function App() {
             <h2 className="text-xl font-semibold mb-4">Primary Button</h2>
             <button
               className="bg-blue-500 hover:bg-blue-600 px-6 py-2 rounded-lg transition-colors w-full"
-              data-clue-id="primary-button"
-              data-clue-click
-              data-clue-click-context={JSON.stringify({
+              data-cv-id="primary-button"
+              data-cv-click
+              data-cv-click-context={JSON.stringify({
                 "click-context":
                   "This context will be attached all click events triggered by this button",
               })}
-              data-clue-context={JSON.stringify({
+              data-cv-context={JSON.stringify({
                 "universal-context":
                   "This context will be attached to all events triggered either by this button or its children",
               })}
@@ -89,9 +89,9 @@ export function App() {
             <h2 className="text-xl font-semibold mb-4">Secondary Button</h2>
             <button
               className="bg-gray-600 hover:bg-gray-500 px-6 py-2 rounded-lg transition-colors w-full"
-              data-clue-id="secondary-button"
-              data-clue-click
-              data-clue-context={JSON.stringify({
+              data-cv-id="secondary-button"
+              data-cv-click
+              data-cv-context={JSON.stringify({
                 "universal-context":
                   "This context will be attached to all events triggered either by this button or its children",
               })}

--- a/examples/react/tsconfig.json
+++ b/examples/react/tsconfig.json
@@ -19,8 +19,8 @@
     "baseUrl": ".",
     "paths": {
       /* TODO: Remove these when the packages are published */
-      "@clue/core": ["../../packages/core/src"],
-      "@clue/click-tracker": ["../../packages/trackers/click-tracker/src"],
+      "@cluesive/core": ["../../packages/core/src"],
+      "@cluesive/click-tracker": ["../../packages/trackers/click-tracker/src"],
     }
   },
   "include": ["src", "../../packages/*/src"]

--- a/examples/react/vite.config.ts
+++ b/examples/react/vite.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
   resolve: {
     alias: {
       // TODO: Remove these once the packages are published
-      '@clue/core': '../../../packages/core/src',
-      '@clue/click-tracker': '../../../packages/trackers/click-tracker/src',
+      '@cluesive/core': '../../../packages/core/src',
+      '@cluesive/click-tracker': '../../../packages/trackers/click-tracker/src',
     },
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "clue-monorepo",
+  "name": "cluesive-monorepo",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "clue-monorepo",
+      "name": "cluesive-monorepo",
       "version": "0.0.0",
       "workspaces": [
         "packages/*"
@@ -90,7 +90,7 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "node_modules/@clue/core": {
+    "node_modules/@cluesive/core": {
       "resolved": "packages/core",
       "link": true
     },
@@ -4864,7 +4864,7 @@
       }
     },
     "packages/core": {
-      "name": "@clue/core",
+      "name": "@cluesive/core",
       "version": "0.0.1",
       "dependencies": {
         "idb": "^8.0.0",
@@ -4878,7 +4878,7 @@
       }
     },
     "packages/utils": {
-      "name": "@clue/utils",
+      "name": "@cluesive/utils",
       "version": "0.0.1",
       "extraneous": true,
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "clue-monorepo",
+  "name": "cluesive-monorepo",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@clue/core",
+  "name": "@cluesive/core",
   "version": "0.0.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/core/src/__tests__/storage.test.ts
+++ b/packages/core/src/__tests__/storage.test.ts
@@ -58,7 +58,7 @@ describe("StorageManager", () => {
       await expect(storageManager.init()).resolves.toBeUndefined();
       expect(openDB).toHaveBeenCalledTimes(1);
       expect(openDB).toHaveBeenCalledWith(
-        "clue_tracking",
+        "cluesive_tracking",
         1,
         expect.any(Object)
       );

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,8 +10,8 @@ import { Logger } from "./logger";
 
 const isOnBrowser = typeof window !== "undefined";
 
-export class Clue {
-  private static instance: Clue | null = null;
+export class Cluesive {
+  private static instance: Cluesive | null = null;
   private events: TrackingEvent[] = [];
   private syncingInterval: number;
   private maxBatchSizeInKB: BatchSize;
@@ -61,13 +61,13 @@ export class Clue {
     }
   }
 
-  public static init(options?: TrackerOptions): Clue {
-    if (!Clue.instance) {
-      Clue.instance = new Clue(options);
+  public static init(options?: TrackerOptions): Cluesive {
+    if (!Cluesive.instance) {
+      Cluesive.instance = new Cluesive(options);
     } else if (options) {
-      Clue.instance.updateOptions(options);
+      Cluesive.instance.updateOptions(options);
     }
-    return Clue.instance;
+    return Cluesive.instance;
   }
 
   public async start(): Promise<void> {

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -2,7 +2,7 @@ export class Logger {
   private isDebug: boolean;
   private prefix: string;
 
-  constructor(isDebug: boolean = false, prefix: string = '[clue]') {
+  constructor(isDebug: boolean = false, prefix: string = '[cluesive]') {
     this.isDebug = isDebug;
     this.prefix = prefix;
   }

--- a/packages/core/src/storage.ts
+++ b/packages/core/src/storage.ts
@@ -1,10 +1,10 @@
 import { openDB, DBSchema, IDBPDatabase } from "idb";
 import { type TrackingEvent } from "./types";
 
-const DB_NAME = "clue_tracking";
+const DB_NAME = "cluesive_tracking";
 const EVENTS_STORE = "pending_events";
 
-interface clueDB extends DBSchema {
+interface CluesiveDB extends DBSchema {
   [EVENTS_STORE]: {
     key: [string, number];
     value: TrackingEvent;
@@ -12,13 +12,13 @@ interface clueDB extends DBSchema {
 }
 
 export class StorageManager {
-  private db: IDBPDatabase<clueDB> | null = null;
+  private db: IDBPDatabase<CluesiveDB> | null = null;
   private initPromise: Promise<void> | null = null;
 
   public async init(): Promise<void> {
     if (this.initPromise) return this.initPromise;
     this.initPromise = (async () => {
-      this.db = await openDB<clueDB>(DB_NAME, 1, {
+      this.db = await openDB<CluesiveDB>(DB_NAME, 1, {
         upgrade(db) {
           if (!db.objectStoreNames.contains(EVENTS_STORE)) {
             db.createObjectStore(EVENTS_STORE, {
@@ -32,7 +32,7 @@ export class StorageManager {
     return this.initPromise;
   }
 
-  private getDatabase(): IDBPDatabase<clueDB> {
+  private getDatabase(): IDBPDatabase<CluesiveDB> {
     if (!this.db) {
       throw new Error("Database not initialized");
     }

--- a/packages/trackers/click-tracker/package.json
+++ b/packages/trackers/click-tracker/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@clue/click-tracker",
+  "name": "@cluesive/click-tracker",
   "version": "0.0.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -12,7 +12,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@clue/core": "workspace:*"
+    "@cluesive/core": "workspace:*"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^1.3.1",

--- a/packages/trackers/click-tracker/src/index.ts
+++ b/packages/trackers/click-tracker/src/index.ts
@@ -2,7 +2,7 @@ import {
   type TrackingEvent,
   type EventDispatcher,
   type Tracker,
-} from "@clue/core";
+} from "@cluesive/core";
 
 export class ClickTracker implements Tracker {
   public readonly name: string;
@@ -38,12 +38,12 @@ export class ClickTracker implements Tracker {
   private onClick(event: MouseEvent): void {
     const timestamp = Date.now();
     const element = event.target as HTMLElement;
-    if (!element.hasAttribute(`data-clue-${this.name}`)) return;
+    if (!element.hasAttribute(`data-cv-${this.name}`)) return;
 
-    const trackId = element.getAttribute("data-clue-id");
-    const universalContextAttribute = element.getAttribute("data-clue-context");
+    const trackId = element.getAttribute("data-cv-id");
+    const universalContextAttribute = element.getAttribute("data-cv-context");
     const localContextAttr = element.getAttribute(
-      `data-clue-${this.name}-context`
+      `data-cv-${this.name}-context`
     );
     let context: Record<string, unknown> = {};
 
@@ -57,7 +57,7 @@ export class ClickTracker implements Tracker {
 
       let parent = element.parentElement;
       while (parent) {
-        const parentContext = parent.getAttribute("data-clue-context");
+        const parentContext = parent.getAttribute("data-cv-context");
         if (parentContext) {
           context = { ...JSON.parse(parentContext), ...context };
         }

--- a/packages/trackers/click-tracker/vitest.config.ts
+++ b/packages/trackers/click-tracker/vitest.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      "@clue/core": "/packages/core/src",
+      "@cluesive/core": "/packages/core/src",
     },
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,9 +14,9 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@clue/core': '/packages/core/src',
-      '@clue/click-tracker': '/packages/trackers/click-tracker/src',
-      '@clue/utils': '/packages/utils/src'
+      '@cluesive/core': '/packages/core/src',
+      '@cluesive/click-tracker': '/packages/trackers/click-tracker/src',
+      '@cluesive/utils': '/packages/utils/src'
     }
   },
 });


### PR DESCRIPTION
Clue and Cluejs npm organization names were already taken, so we're going to switch to Cluesive.